### PR TITLE
Fixing a tricky encoding error

### DIFF
--- a/htmlvalidator/core.py
+++ b/htmlvalidator/core.py
@@ -36,7 +36,7 @@ def validate_html(html, encoding, filename,
         filename
     )
     with codecs.open(temp_file, 'w', encoding) as f:
-        f.write(html)
+        f.write(html.decode(encoding))
         valid = _validate(temp_file, encoding, (args, kwargs))
     if valid:
         os.remove(temp_file)
@@ -73,7 +73,7 @@ def _validate(html_file, encoding, (args, kwargs)):
         buf = StringIO.StringIO()
         gzipper = gzip.GzipFile(fileobj=buf, mode='wb')
         with codecs.open(html_file, 'r', encoding) as f:
-            gzipper.write(f.read())
+            gzipper.write(f.read().encode(encoding))
             gzipper.close()
         gzippeddata = buf.getvalue()
         buf.close()

--- a/htmlvalidator/core.py
+++ b/htmlvalidator/core.py
@@ -106,7 +106,7 @@ def _validate(html_file, encoding, (args, kwargs)):
         'file'
     )
     if output and 'The document is valid' not in output:
-        print "VALIDATON TROUBLE"
+        print "VALIDATION TROUBLE"
         if how_to_ouput == 'stdout':
             print output
             print


### PR DESCRIPTION
I tried to get `django-html-validator` to work for one project of mine and ran in the following problem:

    ======================================================================
    ERROR: test_public_homepage (myproject.tests.CheckPublicPages)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "myproject/hackingweek/tests.py", line 36, in test_public_homepage
        response = self.client.get('/')
      File "/local/lib/python2.7/site-packages/htmlvalidator/client.py", line 52, in get
        (args, kwargs)
      File "/local/lib/python2.7/site-packages/htmlvalidator/core.py", line 39, in validate_html
        f.write(html)
      File "/lib/python2.7/codecs.py", line 688, in write
        return self.writer.write(data)
      File "/lib/python2.7/codecs.py", line 351, in write
        data, consumed = self.encode(object, self.errors)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 108: ordinal not in range(128)

It seemed that the Python code didn't like at all the usage of UTF-8 characters within the webpages. 

I did look a bit at the problem and the code of `django-html-validator` and got this fix to work with my settings. I have no clue if it is working for everybody, so be careful before applying it !

I hope it helps a bit to improve the whole thing because I found your code extremely useful ! Thanks !