### PR TITLE
Avoid deprecation warning with Django 1.7

### DIFF
--- a/htmlvalidator/middleware.py
+++ b/htmlvalidator/middleware.py
@@ -1,5 +1,8 @@
 from django.conf import settings
-from django.contrib.sites.models import RequestSite
+try:
+    from django.contrib.sites.requests import RequestSite
+except Importerror:  # Django < 1.7
+    from django.contrib.sites.models import RequestSite
 
 from .utils import find_charset_encoding
 from .core import validate_html


### PR DESCRIPTION
Django 1.8.2 warns:

<pre>/usr/lib/python3.4/site-packages/django/contrib/sites/models.py:78: RemovedInDjango19Warning: Model class django.contrib.sites.models.Site doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Site(models.Model):

[...]/django-html-validator/htmlvalidator/middleware.py:29: RemovedInDjango19Warning: Please import RequestSite from django.contrib.sites.requests.
  filename = '%s-%s' % (RequestSite(request).domain, filename)</pre>