### PR TITLE
Make vnu validator URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,19 @@ This also **requires java to be installed** because that's how `.jar` files are
 executed on the command line.
 
 Be aware that calling this `vnu.jar` file is quite slow. Over 2 seconds is
-not unusual.
+not unusual. A faster alternative is to use the `vnu.jar` to run a local web
+instance of the validator, and pointing validation to use that by *NOT* setting
+`HTMLVALIDATOR_VNU_JAR` and doing this instead:
 
+```python
+HTMLVALIDATOR_VNU_URL = 'http://localhost:8888/'
+```
 
+The local web instance of the validator can be started typically by:
+
+```
+java -cp vnu.jar nu.validator.servlet.Main 8888
+```
 
 Validating during running the server
 ------------------------------------

--- a/htmlvalidator/core.py
+++ b/htmlvalidator/core.py
@@ -115,7 +115,7 @@ def _validate(html_file, encoding, args_kwargs):
         'HTMLVALIDATOR_OUTPUT',
         'file'
     )
-    if output and 'The document is valid' not in output:
+    if output and not re.search(r'The document (is valid|validates)', output):
         print("VALIDATION TROUBLE")
         if how_to_ouput == 'stdout':
             print(output)

--- a/htmlvalidator/core.py
+++ b/htmlvalidator/core.py
@@ -79,8 +79,17 @@ def _validate(html_file, encoding, args_kwargs):
         gzippeddata = buf.getvalue()
         buf.close()
 
+        vnu_url = getattr(
+            settings,
+            'HTMLVALIDATOR_VNU_URL',
+            'http://html5.validator.nu/'
+        )
+
         req = requests.post(
-            'http://html5.validator.nu/?out=text',
+            vnu_url,
+            params={
+                'out': 'text',
+            },
             headers={
                 'Content-Type': 'text/html',
                 'Accept-Encoding': 'gzip',


### PR DESCRIPTION
Using a local vnu web instance makes things much faster than invoking
the CLI version on each request.