### PR TITLE
Pass correct "headers" argument to requests.post

### DIFF
--- a/htmlvalidator/core.py
+++ b/htmlvalidator/core.py
@@ -99,7 +99,7 @@ def _validate(html_file, html, content_type, args_kwargs):
                 'Content-Type': content_type,
                 'Accept-Encoding': 'gzip',
                 'Content-Encoding': 'gzip',
-                'Content-Length': len(gzippeddata),
+                'Content-Length': str(len(gzippeddata)),
             },
             data=gzippeddata
         )

--- a/htmlvalidator/tests/test_client.py
+++ b/htmlvalidator/tests/test_client.py
@@ -3,11 +3,11 @@
 import codecs
 import os
 import shutil
-import sys
 import tempfile
 from glob import glob
 
 import requests
+import six
 from mock import Mock, patch
 
 from htmlvalidator import client
@@ -64,13 +64,10 @@ class ClientTestCase(TestCase):
 
         # Make sure the "headers" argument to htmlvalidator.core.requests.post
         # was a mapping of str to str.
-        using_python_2 = sys.version_info[0] < 3
-        bytestype = str if using_python_2 else bytes
-        stringtype = unicode if using_python_2 else str
         post.assert_called()
         headers = post.call_args[1]['headers']
         for header in headers:
-            self.assertTrue(isinstance(header, stringtype) or
-                            isinstance(header, bytestype))
-            self.assertTrue(isinstance(headers[header], stringtype) or
-                            isinstance(headers[header], bytestype))
+            self.assertTrue(isinstance(header, six.text_type) or
+                            isinstance(header, six.binary_type))
+            self.assertTrue(isinstance(headers[header], six.text_type) or
+                            isinstance(headers[header], six.binary_type))

--- a/htmlvalidator/tests/test_client.py
+++ b/htmlvalidator/tests/test_client.py
@@ -3,6 +3,7 @@
 import codecs
 import os
 import shutil
+import sys
 import tempfile
 from glob import glob
 
@@ -60,3 +61,16 @@ class ClientTestCase(TestCase):
             txt_file, = glob(os.path.join(self.tmpdir, '*.txt'))
             with codecs.open(txt_file, encoding='utf-8') as f:
                 self.assertTrue(content in f.read())
+
+        # Make sure the "headers" argument to htmlvalidator.core.requests.post
+        # was a mapping of str to str.
+        using_python_2 = sys.version_info[0] < 3
+        bytestype = str if using_python_2 else bytes
+        stringtype = unicode if using_python_2 else str
+        post.assert_called()
+        headers = post.call_args[1]['headers']
+        for header in headers:
+            self.assertTrue(isinstance(header, stringtype) or
+                            isinstance(header, bytestype))
+            self.assertTrue(isinstance(headers[header], stringtype) or
+                            isinstance(headers[header], bytestype))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+six


### PR DESCRIPTION
The ["headers" argument to requests.post](http://docs.python-requests.org/en/master/user/quickstart/#custom-headers) is required to be a dictionary where the names and values are strings; however, `Content-Length` was an integer.

It is surprising that this has not been discovered before. It was rendering the module completely unusable for me. Maybe it's the combination of circumstances (I'm doing a post request, using Python 3.4.2 and requests 2.11.0).