### PR TITLE
New Django MIDDLEWARE style classes compatible

### DIFF
--- a/htmlvalidator/middleware.py
+++ b/htmlvalidator/middleware.py
@@ -5,8 +5,18 @@ from .core import validate_html
 
 
 class HTMLValidator(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
 
-    def process_response(self, request, response):
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
         if not getattr(settings, 'HTMLVALIDATOR_ENABLED', False):
             return response
 
@@ -35,3 +45,4 @@ class HTMLValidator(object):
                 ([], request.GET)
             )
         return response
+


### PR DESCRIPTION
Hello, this change let the html validator work with new Django MIDDLEWARE style. This is NOT complatible with older MIDDLEWARE_CLASSES. Though it could have been done, i didn't like to use a deprecation middleware mixin just for the name ;).

Before considering eventually to merge this PR, please note that:
[!] No documentation has been touched, sorry
[!] No tests have been modified, sorry

Though, the middleware works for my project on django 1.11 and new middleware registration (great work, thanks!)