### PR TITLE
Make compatible with new MIDDLEWARE config

### DIFF
--- a/htmlvalidator/middleware.py
+++ b/htmlvalidator/middleware.py
@@ -3,8 +3,12 @@ from django.contrib.sites.requests import RequestSite
 
 from .core import validate_html
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
-class HTMLValidator(object):
+class HTMLValidator(MiddlewareMixin):
 
     def process_response(self, request, response):
         if not getattr(settings, 'HTMLVALIDATOR_ENABLED', False):


### PR DESCRIPTION
FWIW, this is a pattern I've seen used in other repos to make middleware handle `MIDDLEWARE_CLASSES` or `MIDDLEWARE` config without breaking compatibility with older Django versions. I'm using this in Django 1.11, haven't tried it in older versions yet myself.